### PR TITLE
Nissix plugin scope-packages on wix-ui-tpa-connected-generator

### DIFF
--- a/lib/logic/component-wrapper.ts
+++ b/lib/logic/component-wrapper.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs'
 import * as path from 'path'
-import {Analyser as StructureAnalyser} from 'wix-ui-tpa-analyser'
+import {Analyser as StructureAnalyser} from '@wix/wix-ui-tpa-analyser'
 import {Builder} from './builder'
 import {IProjectVariableStructure, VariableAnalyser} from './variable-analyser'
 

--- a/lib/logic/variable-analyser.ts
+++ b/lib/logic/variable-analyser.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as rimraf from 'rimraf'
-import {Analyser} from 'wix-ui-tpa-analyser'
+import {Analyser} from '@wix/wix-ui-tpa-analyser'
 import {IComponentStructure} from '../interfaces/shared'
 import {Builder, IProjectVariableValues} from './builder'
 import {CSS} from './css'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1029,6 +1029,16 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wix/wix-ui-tpa-analyser": {
+      "version": "1.0.0",
+      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@wix/wix-ui-tpa-analyser/-/@wix/wix-ui-tpa-analyser-1.0.0.tgz",
+      "integrity": "sha1-0WTBbjIBoIPGsgRMzBmo21tldU8=",
+      "requires": {
+        "args": "~5.0.1",
+        "find-node-modules": "^2.0.0",
+        "json-beautify": "^1.1.0"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -7827,16 +7837,6 @@
         "classnames": "^2.2.6",
         "wix-ui-core": "^2.0.66",
         "wix-ui-icons-common": "^2.0.0"
-      }
-    },
-    "wix-ui-tpa-analyser": {
-      "version": "1.0.0",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/wix-ui-tpa-analyser/-/wix-ui-tpa-analyser-1.0.0.tgz",
-      "integrity": "sha1-AHzfwIch3V8CbOVTFEWo0Fz5Bks=",
-      "requires": {
-        "args": "~5.0.1",
-        "find-node-modules": "^2.0.0",
-        "json-beautify": "^1.1.0"
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "webpack": "^4.29.6",
     "webpack-cli": "^3.3.0",
     "webpack-node-externals": "^1.7.2",
-    "wix-ui-tpa-analyser": "^1.0.0"
+    "@wix/wix-ui-tpa-analyser": "^1.0.0"
   },
   "devDependencies": {
     "@types/args": "^3.0.0",


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 6.432s
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.9 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.9: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})




Output Log:
Migrating package "wix-ui-tpa-connected-generator" in .


## Migration from non scope to @wix/scoped packages
> /tmp/8773d75c3725bac818618c65d1fb8d95

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
lib/logic/component-wrapper.ts
lib/logic/variable-analyser.ts
```
added 450 packages from 323 contributors and audited 937 packages in 9.146s
found 41956 vulnerabilities (41918 low, 20 moderate, 18 high)
  run `npm audit fix` to fix them, or `npm audit` for details

